### PR TITLE
Update Android Studio & project requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ local.properties
 /captures
 .externalNativeBuild
 .cxx
+mb.log
+mb.pid

--- a/README.md
+++ b/README.md
@@ -1,16 +1,23 @@
 ### Requirements
-> :warning: **If you are using Android Studio 4**, please clone the code at [main branch](https://github.com/techops-recsys-lateral-hiring/mobiledev-wechatmoments-kotlin/tree/main)
-1. Android Studio Artic Fox (2020.3.1) - via [Android Developers](https://developer.android.com/studio)
-2. Android SDK 30 and BuildTools 30.0.3 - via [Android SDK Manager](https://developer.android.com/studio/intro/update#sdk-manager)
-3. Java JDK 11 - via [Termurin OpenJDK](https://adoptium.net/?variant=openjdk11&jvmVariant=hotspot) or [Oracle Java Downloads](https://www.oracle.com/java/technologies/javase/jdk11-archive-downloads.html)
+1. Android Studio Bumblebee (2021.1.1) - via [Android Developers](https://developer.android.com/studio)
+2. Android SDK 31 and BuildTools 30.0.3 - via [Android SDK Manager](https://developer.android.com/studio/intro/update#sdk-manager)
+3. Java JDK 11 - via [Azul OpenJDK](https://www.azul.com/downloads/?version=java-11-lts&package=jdk) or [Oracle Java Downloads](https://www.oracle.com/java/technologies/javase/jdk11-archive-downloads.html)
 4. npm - via [Node.js installer](https://nodejs.org/en/download/) or [nvm](https://github.com/nvm-sh/nvm#install--update-script)
+
+### Setup nvm
+1. Open terminal
+2. Execute `curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash`
+3. Execute `nvm install 16`
+4. Execute `nvm use 16`
+5. Execute `npm install -g mountebank`
+6. Execute `npm install -g npm@8.4.1`
+7. Execute `npm audit fix`
 
 ### Setup the project
 1. Locate the current directory in terminal
-3. Execute `npm install -g mountebank`
-4. Execute `mb --configfile imposters.ejs`
-5. Open `build.gradle` in the current directory
-6. Run the project and make sure the app can start correctly(don't worry about if the features are working properly)
+2. Execute `mb --configfile imposters.ejs`
+3. Open `build.gradle` in the current directory
+4. Run the project and make sure the app can start correctly(don't worry about if the features are working properly)
 
 ### App Introduction
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 ### Requirements
 > :warning: **If you are using Android Studio 4**, please clone the code at [main branch](https://github.com/techops-recsys-lateral-hiring/mobiledev-wechatmoments-kotlin/tree/main)
-1. npm - via [Node.js installer](https://nodejs.org/en/download/) or [nvm](https://github.com/nvm-sh/nvm#install--update-script)
+1. Android Studio Artic Fox (2020.3.1) - via [Android Developers](https://developer.android.com/studio)
+2. Android SDK 30 and BuildTools 30.0.3 - via [Android SDK Manager](https://developer.android.com/studio/intro/update#sdk-manager)
+3. Java JDK 11 - via [Termurin OpenJDK](https://adoptium.net/?variant=openjdk11&jvmVariant=hotspot) or [Oracle Java Downloads](https://www.oracle.com/java/technologies/javase/jdk11-archive-downloads.html)
+4. npm - via [Node.js installer](https://nodejs.org/en/download/) or [nvm](https://github.com/nvm-sh/nvm#install--update-script)
 
 ### Setup the project
 1. Locate the current directory in terminal

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ### Requirements
+> :warning: **If you are using Android Studio 4**, please clone the code at [main branch](https://github.com/techops-recsys-lateral-hiring/mobiledev-wechatmoments-kotlin/tree/main)
 1. npm - via [Node.js installer](https://nodejs.org/en/download/) or [nvm](https://github.com/nvm-sh/nvm#install--update-script)
 
 ### Setup the project

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     defaultConfig {
         applicationId "com.tws.moments"
         minSdkVersion 20
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
 
@@ -37,36 +37,34 @@ android {
 }
 
 dependencies {
-//    implementation project(':tw-image-loader')
     implementation fileTree(dir: "libs", include: ["*.jar"])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.6.0'
-    implementation 'androidx.appcompat:appcompat:1.3.1'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.1'
+    implementation 'androidx.core:core-ktx:1.7.0'
+    implementation 'androidx.appcompat:appcompat:1.4.1'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
 
     implementation 'com.github.bumptech.glide:glide:4.12.0'
 
-    implementation "androidx.fragment:fragment-ktx:1.3.6"
+    implementation "androidx.fragment:fragment-ktx:1.4.1"
     implementation "androidx.lifecycle:lifecycle-extensions:2.2.0"
-    implementation "androidx.lifecycle:lifecycle-livedata-ktx:2.3.1"
-    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.1"
+    implementation "androidx.lifecycle:lifecycle-livedata-ktx:2.4.1"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.4.1"
 
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
     implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
     implementation 'com.jakewharton.retrofit:retrofit2-kotlin-coroutines-adapter:0.9.2'
 
-    implementation 'com.google.code.gson:gson:2.8.6'
+    implementation 'com.google.code.gson:gson:2.9.0'
     implementation 'androidx.test.ext:junit-ktx:1.1.3'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'androidx.test:core:1.4.0'
-    testImplementation 'org.mockito:mockito-core:2.19.0'
-    testImplementation "io.mockk:mockk:1.12.0"
-    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.1"
+    testImplementation 'org.mockito:mockito-core:4.2.0'
+    testImplementation 'io.mockk:mockk:1.12.2'
+    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0'
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.5.1'
-    testImplementation "androidx.arch.core:core-testing:2.1.0"
+    testImplementation 'androidx.arch.core:core-testing:2.1.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,7 +33,7 @@ android {
     testOptions {
         unitTests.includeAndroidResources = true
     }
-    buildToolsVersion '29.0.2'
+    buildToolsVersion '30.0.3'
 }
 
 dependencies {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,7 +13,9 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
         android:usesCleartextTraffic="true">
-        <activity android:name=".MainActivity">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.3'
+        classpath 'com.android.tools.build:gradle:7.0.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.2'
+        classpath 'com.android.tools.build:gradle:7.0.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,12 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.5.20"
+    ext.kotlin_version = "1.6.20"
     repositories {
         google()
-        jcenter()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.4'
+        classpath 'com.android.tools.build:gradle:7.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -18,7 +17,6 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
         mavenCentral()
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Jul 02 23:15:09 CST 2020
+#Thu Dez 09 19:10:09 UTC-3 2021
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip


### PR DESCRIPTION
Branch based on top of as_articfox - this needs to become the new standard:

Codebase:
- Update libs 
- Update compile & target SDKs to 31
- Update kotlin 1.6.20
- Update gradle build tools
- Update gradle wrapper
- Remove deprecated jcenter() repositories

Update README.md file:
- Update Android Studio version to latest Bumblebee 2021.1.1  & Android SDK to 31
- Change recommended Java SDK to Azul OpenJDK that also support Apple Silicon
- Added full steps to setup nvm
